### PR TITLE
Increase fftSize to 4096

### DIFF
--- a/JsSpeechRecognizer.js
+++ b/JsSpeechRecognizer.js
@@ -54,7 +54,7 @@ function JsSpeechRecognizer() {
     this.analyser.minDecibels = -80;
     this.analyser.maxDecibels = -10;
     this.analyser.smoothingTimeConstant = 0;
-    this.analyser.fftSize = 1024;
+    this.analyser.fftSize = 4096;
 
     // Create the scriptNode
     this.scriptNode = this.audioCtx.createScriptProcessor(this.analyser.fftSize, 1, 1);


### PR DESCRIPTION
This prevents choppy recordings on some devices (like Chrome for Android). fftSize is [defined here](https://webaudio.github.io/web-audio-api/#idl-def-AnalyserNode).

Kudos to @padenot for finding the trick and giving the explanation 😃 

r? @samgiles 
